### PR TITLE
BM-6 [feat]: JWT 토큰필터추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly('io.jsonwebtoken:jjwt-jackson:0.11.5') // or jjwt-gson, jjwt-orgjson
 }
 
 tasks.named('test') {

--- a/src/main/java/com/bidmall/gateway/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/bidmall/gateway/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.bidmall.gateway.filter;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import reactor.core.publisher.Mono;
+
+@Component
+public class JwtAuthenticationFilter implements GlobalFilter {
+	@Value("${jwt.secret}")
+	private String secret;
+
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+		ServerHttpRequest request = exchange.getRequest();
+		String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+		if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+			return unauthorized(exchange);
+		}
+
+		String token = authHeader.substring(7);
+		try {
+			return chain.filter(exchange.mutate()
+				.request(getHeader(exchange, parsingToken(token))).build());
+		} catch (JwtException e) {
+			return unauthorized(exchange);
+		}
+	}
+
+	private Claims parsingToken(String token) {
+		Claims claims = Jwts.parser()
+			.setSigningKey(secret)
+			.parseClaimsJws(token)
+			.getBody();
+		return claims;
+	}
+
+	private static ServerHttpRequest getHeader(ServerWebExchange exchange, Claims claims) {
+		ServerHttpRequest request;
+		request = exchange.getRequest().mutate()
+			.header("X-User-Id", claims.getSubject())
+			.build();
+		return request;
+	}
+
+	private Mono<Void> unauthorized(ServerWebExchange exchange) {
+		exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+		return exchange.getResponse().setComplete();
+	}
+}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,3 +54,7 @@ management:
   endpoint:
     health:
       show-details: always
+
+jwt:
+  secret: my-secret-key-for-jwt-signing
+  expiration: 3600000 #1시간


### PR DESCRIPTION
BM-6 [feat]: JWT 토큰필터추가

BM5에서 작업을 진행했습니다. 참고부탁드립니다.

진행사항 목록
1.Authorization 헤더에서 Bearer 토큰 파싱
2.시크릿 키 기반으로 JWT 파싱 및 검증
3.인증 성공 시, X-User-Id 헤더에 claims.getSubject() 담아 downstream 서비스로 전달
4.인증 실패 시 401 Unauthorized 응답

GlobalFilter vs GatewayFilter 중 고민하다가 전체 요청에 적용되는 점과 단순 인증 역할이라 GlobalFilter로 구현했습니다.
요구사항이 생성까지 추가가 되면 변경하도록 구현하겠습니다.